### PR TITLE
Remove reference to deprecated attr/xattr.h

### DIFF
--- a/System/Xattr.hsc
+++ b/System/Xattr.hsc
@@ -45,11 +45,7 @@ module System.Xattr
     where
 
 #include <sys/types.h>
-#ifdef __APPLE__
 #include <sys/xattr.h>
-#else
-#include <attr/xattr.h>
-#endif
 
 import Data.Functor ((<$>))
 import Foreign.C


### PR DESCRIPTION
Version 2.4.48 or attr removed attr/xattr.h and
recommends to use sys/xattr.h instead. For
reference see:

https://git.savannah.nongnu.org/cgit/attr.git/commit/?id=7921157890d07858d092f4003ca4c6bae9fd2c38

I stumbled upon this through https://github.com/NixOS/nixpkgs/issues/53716.